### PR TITLE
Change default clamtk directory from `.clamtk` to `.config/clamtk` in `App.pm`

### DIFF
--- a/lib/App.pm
+++ b/lib/App.pm
@@ -44,12 +44,11 @@ sub get_path {
     $path->{ directory } = $ENV{ HOME } || ( ( getpwuid $< )[ -2 ] );
 
     # Default personal clamtk directory
-    $path->{ clamtk } = $path->{ directory } . '/.clamtk';
     $path->{ clamtk }
         = ( -d $path->{ directory } . '/.clamtk' )  ? $path->{ directory } . '/.clamtk'
         : ( defined $ENV{CLAMTK_HOME} )             ? $ENV{CLAMTK_HOME}
         : ( defined $ENV{XDG_CONFIG_HOME} )         ? $ENV{XDG_CONFIG_HOME} . '/clamtk'  
-        : $path->{ directory } . '/.clamtk';
+        : $path->{ directory } . '/.config/clamtk';
 
     # Trash directory - main
     $path->{ trash_dir } = $path->{ directory } . '/.local/share/Trash';


### PR DESCRIPTION
The [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) says If `$XDG_CONFIG_HOME` is either not set or empty, a default equal to `$HOME/.config` should be used, so the clamtk user directory should default to `~/.config/clamtk` (unless `~/clamtk` already exists), not `~/.clamtk`